### PR TITLE
Update safe_strncpy.c

### DIFF
--- a/libbb/safe_strncpy.c
+++ b/libbb/safe_strncpy.c
@@ -14,7 +14,7 @@ char* FAST_FUNC safe_strncpy(char *dst, const char *src, size_t size)
 {
 	if (!size) return dst;
 	dst[--size] = '\0';
-	return strncpy(dst, src, size);
+	return strncpy(dst, src, --size);
 }
 
 /* Like strcpy but can copy overlapping strings. */


### PR DESCRIPTION
If there is no null byte among the first 'size' bytes of src, 
the dst string will 'still not' be null-terminated.