### PR TITLE
adduser: Allow '@', '%', '/' and '\' in username

### DIFF
--- a/libbb/die_if_bad_username.c
+++ b/libbb/die_if_bad_username.c
@@ -32,6 +32,10 @@ void FAST_FUNC die_if_bad_username(const char *name)
 		/* These chars are valid unless they are at the 1st pos: */
 		if (*name == '-'
 		 || *name == '.'
+		 || *name == '@'
+		 || *name == '%'
+		 || *name == '/'
+		 || *name == '\\'
 		/* $ is allowed if it's the last char: */
 		 || (*name == '$' && !name[1])
 		) {


### PR DESCRIPTION
Allow '@', '%', '/' and '\' in username for adduser command to support
usernames in the form of :

  username@domain
  username%domain
  domain/username
  domain\username

Username in those forms may have some limitations in various services
like email, ssh, but simply disallowing them prevents more generic
use of the username based on email address or name with realm.