### PR TITLE
Update tar.c

### DIFF
--- a/archival/tar.c
+++ b/archival/tar.c
@@ -744,7 +744,11 @@ static llist_t *append_file_list_to_list(llist_t *list)
 				*cp = '\0';
 			llist_add_to_end(&newlist, line);
 		}
-		fclose(src_stream);
+		
+		if(src_stream != stdin)
+		{
+			fclose(src_stream);
+		}
 	}
 	return newlist;
 }


### PR DESCRIPTION
Fixing bug which causes tar to close stdin when running with the flag -T with "-" (reading input from stdin)