### PR TITLE
No -w option if no FEATURE_FTPD_WRITE

### DIFF
--- a/networking/ftpd.c
+++ b/networking/ftpd.c
@@ -54,7 +54,7 @@
 //kbuild:lib-$(CONFIG_FTPD) += ftpd.o
 
 //usage:#define ftpd_trivial_usage
-//usage:       "[-wvS]"IF_FEATURE_FTPD_AUTHENTICATION(" [-a USER]")" [-t N] [-T N] [DIR]"
+//usage:       "[-"IF_FEATURE_FTPD_WRITE("w")"vS]"IF_FEATURE_FTPD_AUTHENTICATION(" [-a USER]")" [-t N] [-T N] [DIR]"
 //usage:#define ftpd_full_usage "\n\n"
 //usage:	IF_NOT_FEATURE_FTPD_AUTHENTICATION(
 //usage:       "Anonymous FTP server. Client access occurs under ftpd's UID.\n"
@@ -68,7 +68,9 @@
 //usage:       "Can be run from tcpsvd:\n"
 //usage:       "	tcpsvd -vE 0.0.0.0 21 ftpd /files/to/serve"
 //usage:     "\n"
+//usage:	IF_FEATURE_FTPD_WRITE(
 //usage:     "\n	-w	Allow upload"
+//usage:	)
 //usage:	IF_FEATURE_FTPD_AUTHENTICATION(
 //usage:     "\n	-A	No login required, client access occurs under ftpd's UID"
 //


### PR DESCRIPTION
When FEATURE_FTPD_WRITE feature is not activated, do not display the "-w" option in the help.

Signed-off-by: Rachid Koucha <rachid.koucha@gmail.com>