### PR TITLE
crond: add support for log level 9 for silent operation

### DIFF
--- a/miscutils/crond.c
+++ b/miscutils/crond.c
@@ -209,6 +209,14 @@ static void log8(const char *msg, ...)
 	va_end(va);
 }
 
+static void log9(const char *msg, ...)
+{
+	va_list va;
+	va_start(va, msg);
+	crondlog(9, msg, va);
+	va_end(va);
+}
+
 
 static const char DowAry[] ALIGN1 =
 	"sun""mon""tue""wed""thu""fri""sat"


### PR DESCRIPTION
Adding this higher log level gives users the option of running cron silently.  As none of the functions in this binary use a log level higher than 8 this should allow for silent running of cron jobs, except for startup.  This can be helpful in the case of a user who has jobs that run very often (once per minute) and wants to avoid filling the system log with that information.

Tested on OpenWrt by setting system cronloglevel to 9.  Before this patch log level 9 had no effect, it continued to run as log level 8.

Signed-off-by: Nicholas Smith <nicholas.smith@telcoantennas.com.au>