### PR TITLE
diff: fix return code of opt errors

### DIFF
--- a/editors/diff.c
+++ b/editors/diff.c
@@ -981,6 +981,7 @@ int diff_main(int argc UNUSED_PARAM, char **argv)
 
 	INIT_G();
 
+	xfunc_error_retval = 2;
 	/* exactly 2 params; collect multiple -L <label>; -U N */
 	GETOPT32(argv, "^" "abdiL:*NqrsS:tTU:+wupBE" "\0" "=2"
 			LONGOPTS,
@@ -990,7 +991,6 @@ int diff_main(int argc UNUSED_PARAM, char **argv)
 		label[!!label[0]] = llist_pop(&L_arg);
 
 	/* Compat: "diff file name_which_doesnt_exist" exits with 2 */
-	xfunc_error_retval = 2;
 	for (i = 0; i < 2; i++) {
 		file[i] = argv[i];
 		if (LONE_DASH(file[i])) {


### PR DESCRIPTION
BusyBox's diff (confirmed at v1.36.0 (987be932e)) return '1' for its option errors instead of '2'. 

This is because the location of 'xfunc_error_retval = 2;' is not correct and fixed by moving it.