### PR TITLE
Remove extra space making uptime more parser friendly - uptime.c

### DIFF
--- a/procps/uptime.c
+++ b/procps/uptime.c
@@ -83,7 +83,7 @@ int uptime_main(int argc UNUSED_PARAM, char **argv UNUSED_PARAM)
 		return EXIT_SUCCESS;
 	}
 
-	printf(" %02u:%02u:%02u up ",
+	printf("%02u:%02u:%02u up ",
 			current_time->tm_hour, current_time->tm_min, current_time->tm_sec
 	);
 	updays = (unsigned) info.uptime / (unsigned)(60*60*24);


### PR DESCRIPTION
Removed the empty space at the beginning of the default print statement. 

From my understanding (not verified) the extra space is there so that the output aligns with some more commands like `top vmstat mpstat iostat netstat df free` and it was passed along overtime for backwards compatibility. The problem is those utils got rid of the space and now `uptime` is not aligned with nothing.