### PR TITLE
fix 'make menuconfig' requires the ncurses libraries issue on fedora

### DIFF
--- a/scripts/kconfig/lxdialog/check-lxdialog.sh
+++ b/scripts/kconfig/lxdialog/check-lxdialog.sh
@@ -47,7 +47,7 @@ trap "rm -f $tmp" 0 1 2 3 15
 check() {
         $cc -x c - -o $tmp 2>/dev/null <<'EOF'
 #include CURSES_LOC
-main() {}
+int main() {}
 EOF
 	if [ $? != 0 ]; then
 	    echo " *** Unable to find the ncurses libraries or the"       1>&2


### PR DESCRIPTION
fix 'make menuconfig' requires the ncurses libraries issue on fedora. refer to https://bbs.archlinux.org/viewtopic.php?id=295859