### PR TITLE
Add #if branch to networking/tc.c  noting that linux kernel version above 6.8 removed cbq support.

### DIFF
--- a/networking/tc.c
+++ b/networking/tc.c
@@ -31,7 +31,7 @@
 //usage:	"qdisc [handle QHANDLE] [root|"IF_FEATURE_TC_INGRESS("ingress|")"parent CLASSID]\n"
 /* //usage: "[estimator INTERVAL TIME_CONSTANT]\n" */
 //usage:	"	[[QDISC_KIND] [help|OPTIONS]]\n"
-//usage:	"	QDISC_KIND := [p|b]fifo|tbf|prio|cbq|red|etc.\n"
+//usage:	"	QDISC_KIND := [p|b]fifo|tbf|prio|cbq(under kernel 6.8)|red|etc.\n"
 //usage:	"qdisc show [dev STRING]"IF_FEATURE_TC_INGRESS(" [ingress]")"\n"
 //usage:	"class [classid CLASSID] [root|parent CLASSID]\n"
 //usage:	"	[[QDISC_KIND] [help|OPTIONS] ]\n"
@@ -49,6 +49,7 @@
 #include "libiproute/ip_common.h"
 #include "libiproute/rt_names.h"
 #include <linux/pkt_sched.h> /* for the TC_H_* macros */
+#include <linux/version.h>/* for cbq support */
 
 /* This is the deprecated multiqueue interface */
 #ifndef TCA_PRIO_MAX
@@ -231,6 +232,7 @@ static int cbq_parse_opt(int argc, char **argv, struct nlmsghdr *n)
 	return 0;
 }
 #endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0)
 static int cbq_print_opt(struct rtattr *opt)
 {
 	struct rtattr *tb[TCA_CBQ_MAX+1];
@@ -322,7 +324,7 @@ static int cbq_print_opt(struct rtattr *opt)
  done:
 	return 0;
 }
-
+#endif
 static FAST_FUNC int print_qdisc(
 		const struct sockaddr_nl *who UNUSED_PARAM,
 		struct nlmsghdr *hdr,
@@ -373,7 +375,11 @@ static FAST_FUNC int print_qdisc(
 		if (qqq == 0) { /* pfifo_fast aka prio */
 			prio_print_opt(tb[TCA_OPTIONS]);
 		} else if (qqq == 1) { /* class based queuing */
+            #if LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0)
 			cbq_print_opt(tb[TCA_OPTIONS]);
+            #else
+            printf("cbq not supported above linux kernel 6.8.0!");
+            #endif
 		} else {
 			/* don't know how to print options for this qdisc */
 			printf("(options for %s)", name);
@@ -444,7 +450,11 @@ static FAST_FUNC int print_class(
 			/* nothing. */ /*prio_print_opt(tb[TCA_OPTIONS]);*/
 		} else if (qqq == 1) { /* class based queuing */
 			/* cbq_print_copt() is identical to cbq_print_opt(). */
+            #if LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0)
 			cbq_print_opt(tb[TCA_OPTIONS]);
+            #else
+            printf("cbq not supported above linux kernel 6.8.0!");
+            #endif
 		} else {
 			/* don't know how to print options for this class */
 			printf("(options for %s)", name);


### PR DESCRIPTION
This bug was already been discussed here https://bugs.busybox.net/show_bug.cgi?id=15931

Linux kernel above 6.8 removes support for cbq queue, which leads to a compile failure in networking/tc.c. I fix it simply by using KERNEL_VERSION.

**Until now, this hasn't fixed by busybox official yet.**