### PR TITLE
Improve the sanity check for the ncurses library 

### DIFF
--- a/scripts/kconfig/lxdialog/check-lxdialog.sh
+++ b/scripts/kconfig/lxdialog/check-lxdialog.sh
@@ -47,7 +47,7 @@ trap "rm -f $tmp" 0 1 2 3 15
 check() {
         $cc -x c - -o $tmp 2>/dev/null <<'EOF'
 #include CURSES_LOC
-main() {}
+int main() {}
 EOF
 	if [ $? != 0 ]; then
 	    echo " *** Unable to find the ncurses libraries or the"       1>&2


### PR DESCRIPTION
Since main was initialized as int and there was no return 0; so its returning an error on compilation of the busybox 
as this
<stdin>:2:1: error: return type defaults to 'int' [-Wimplicit-int]
which gets propogated to the make menuconfig and shows this error even when libncurses is already present
```
root@183ae334d9f9:/workspace/busybox# make menuconfig V=1
make -f scripts/Makefile.build obj=scripts/basic
/workspace/busybox/scripts/gen_build_files.sh /workspace/busybox /workspace/busybox
mkdir -p include
make -f scripts/Makefile.build obj=scripts/kconfig menuconfig
make -f scripts/Makefile.build obj=scripts/kconfig/lxdialog
/bin/bash /workspace/busybox/scripts/kconfig/lxdialog/check-lxdialog.sh -check gcc -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -DCURSES_LOC="<ncurses.h>" -DNCURSES_WIDECHAR=1 -DLOCALE -lncursesw -ltinfo
 *** Unable to find the ncurses libraries or the
 *** required header files.
 *** 'make menuconfig' requires the ncurses libraries.
 ***
 *** Install ncurses (ncurses-devel) and try again.
 ***
make[2]: *** [/workspace/busybox/scripts/kconfig/lxdialog/Makefile:15: scripts/kconfig/lxdialog/dochecklxdialog] Error 1
make[1]: *** [/workspace/busybox/scripts/kconfig/Makefile:14: menuconfig] Error 2
make: *** [Makefile:444: menuconfig] Error 2
```

Solves #103 